### PR TITLE
Updated AttestationStation link typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Sybil resistant referral system where each new address a user gets to use OP is 
 ### 🔰 **`NFTs`**
 
 **Composable Allowlists**
-Create a way for projects to allowlist certain addresses and make those allowlists shareable using the [AttestationStation](optimism.io/reputation)
+Create a way for projects to allowlist certain addresses and make those allowlists shareable using the [AttestationStation](https://optimism.io/reputation)
 
 **L2 Gift Cards**  
 An L1 NFT that sends ETH or OP to your L2 address when bridged over.  


### PR DESCRIPTION

**Description**

Hyperlink pointing to AttestationStation documentation was broken. Fixed it.


**Additional context**

OP is OP


